### PR TITLE
41 Define Python Home Upon Load: Fix

### DIFF
--- a/OpenTap.Python/PythonInitializer.cs
+++ b/OpenTap.Python/PythonInitializer.cs
@@ -66,6 +66,12 @@ def add_dir(x):
                     }
 
                     Runtime.PythonDLL = pyLoc;
+                    // In some cases the python home is not known.
+                    // if som try to get it from pyPath.
+                    // only done on windows, because it is less ambiguous on Linux when 
+                    // python is installed with a package.
+                    if(pyPath != null && SharedLib.IsWin32 && PythonEngine.PythonHome == "")
+                        PythonEngine.PythonHome = pyPath;
 
                     PythonEngine.Initialize(false);
                     PythonEngine.BeginAllowThreads();

--- a/OpenTap.Python/PythonInstallationDiscoverer.cs
+++ b/OpenTap.Python/PythonInstallationDiscoverer.cs
@@ -107,8 +107,13 @@ class PythonDiscoverer
                 var loc = TryFindPythons(targetFolder).FirstOrDefault();
                 if (loc != null && pythonVersionParser.IsMatch(loc))
                 {
+                    // if the target file folder contains a Lib folder,
+                    // then it can probably be used as a PythonHome.
+                    var fld = Path.GetDirectoryName(loc);
+                    if (fld != null && !Directory.Exists(Path.Combine(fld, "Lib")))
+                        fld = null;
                     Int32.TryParse(pythonVersionParser.Match(loc).Groups["v"].Value, out int weight);
-                    yield return (loc, null, weight);
+                    yield return (loc, fld, weight);
                 }
             }
         }


### PR DESCRIPTION
Added loading python home dynamically on Windows.

Close #41 

Close #32

Note, #32 was already fixed, but a python home issue caused some problems related to it.


