### PR TITLE
82 Search In Program Files: Fix

### DIFF
--- a/.gitversion
+++ b/.gitversion
@@ -3,7 +3,7 @@
 
 # This is the version number that will be used. Prerelease numbers are calculated by 
 # counting git commits since the last change in this value.
-version = 3.0.1
+version = 3.0.2
 
 # A version is determined to be a "beta" prerelease if it originates from the default branch
 # The default branch is the first branch that matches the following regular expession.

--- a/OpenTap.Python/PythonInstallationDiscoverer.cs
+++ b/OpenTap.Python/PythonInstallationDiscoverer.cs
@@ -65,8 +65,9 @@ class PythonDiscoverer
         var programFiles4 = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "WindowsApps");
         var programFiles5 = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "Programs", "Python");
+        var programFiles6 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
 
-        return drives.Concat(new[] { programFiles, programFiles2, programFiles3, programFiles4, programFiles5 })
+        return drives.Concat(new[] { programFiles, programFiles6, programFiles2, programFiles3, programFiles4, programFiles5 })
             .SelectMany(GetPythonsInFolder).Distinct().ToArray();
     }
 


### PR DESCRIPTION
Fixed the bug by (re)adding the Program Files folder as a directory to be searched.

Close #82 