### PR TITLE
Detect when opentap.py cannot be loaded, it is the same as an initial…

### DIFF
--- a/OpenTap.Python/PythonInitializer.cs
+++ b/OpenTap.Python/PythonInitializer.cs
@@ -103,6 +103,7 @@ def add_dir(x):
                     catch (PythonException e)
                     {
                         PrintPythonException(e);
+                        return false;
                     }
                 }
             }


### PR DESCRIPTION
…ization error

This is a fix for #87, although it does not entirely fix the issue, it should circumvent it.