### PR TITLE
92 Cancel Key Press Fix: Fix

### DIFF
--- a/OpenTap.Python.Examples/BasicInstrument.py
+++ b/OpenTap.Python.Examples/BasicInstrument.py
@@ -5,6 +5,7 @@
 from opentap import *
 from System import Double, String
 import OpenTap
+import math
 
 @attribute(OpenTap.Display("Basic Instrument", "A basic example of an instrument driver.", "Python Example"))
 class BasicInstrument(Instrument):

--- a/OpenTap.Python/PythonInitializer.cs
+++ b/OpenTap.Python/PythonInitializer.cs
@@ -103,6 +103,8 @@ def add_dir(x):
                     catch (PythonException e)
                     {
                         PrintPythonException(e);
+                        log.Error("Unable to initialize OpenTAP.");
+                                
                         return false;
                     }
                 }

--- a/OpenTap.Python/opentap.py
+++ b/OpenTap.Python/opentap.py
@@ -11,19 +11,13 @@ __copyright__ = """
 
 import sys
 import clr
-import math
-import types
-import traceback
-import weakref
-import subprocess
+import traceback    
 import os
 
 clr.AddReference("OpenTap")
 clr.AddReference("OpenTap.Python")
 import OpenTap
 import OpenTap.Python
-from System.ComponentModel import Browsable, BrowsableAttribute
-import System
 from System import String, Double, Array, IConvertible
 from System.Collections.Generic import List
 
@@ -48,6 +42,7 @@ if pyexe != None:
     sys.executable = pyexe
 
 def install_package(file):
+    import subprocess
     subprocess.check_call([pyexe, '-m', 'pip', 'install', '-r', os.path.abspath(file)])
 
 debugpy_imported = False


### PR DESCRIPTION
It seems that 'import subprocess' overrides the signal handler inside Python.

Not importing it by default seems to fix the issue.

Close #92


It seems this was caused by calling 'import signal', which is invoked inside subprocess.py.