### PR TITLE
PythonExamples 3.0.2: Fix exception in Basic Functionality Step

### DIFF
--- a/OpenTap.Python.Examples/BasicFunctionality.py
+++ b/OpenTap.Python.Examples/BasicFunctionality.py
@@ -75,7 +75,7 @@ class BasicFunctionality(TestStep): # Inheriting from opentap.TestStep causes it
         
         # Add validation rules for the property. This makes it possible to tell the user about invalid property values.
         self.Rules.Add(opentap.Rule("Frequency", lambda: self.Frequency >= 0, lambda: '{} Hz is an invalid value. Frequency must not be negative'.format(self.Frequency)))
-        self.Rules.Add(opentap.Rule("Frequency", lambda: self.Frequency <= 2e9, 'Frequency cannot be greater than {}.'.format(2e9)))
+        self.Rules.Add(opentap.Rule("Frequency", lambda: self.Frequency <= 2e9, lambda: 'Frequency cannot be greater than {}.'.format(2e9)))
     
         
 


### PR DESCRIPTION
Fixes exception which is thrown if the second rule in the Basic Functionality Step detects a value which exceeds the upper limit:

```
14:57:44.093  TestStep     Caught exception while getting validation error: 'str' object is not callable
14:57:44.099  TestStep     PythonException: 'str' object is not callable
14:57:44.112  TestStep         File "C:\Program Files\OpenTAP\Packages\Python\opentap.py", line 77, in Error
14:57:44.112  TestStep         return self.errorFunc()
14:57:44.112  TestStep         ^^^^^^^^^^^^^^^^
14:57:44.112  TestStep         at Python.Runtime.PythonException.ThrowLastAsClrException()
14:57:44.112  TestStep         at Python.Runtime.PyObject.Invoke(PyObject[] args)
14:57:44.112  TestStep         at Python.Runtime.PythonDerivedType.InvokeMethod[T](IPythonDerivedType obj, String methodName, String origMethodName, Object[] args, RuntimeMethodHandle methodHandle)
14:57:44.112  TestStep         at OpenTap.py.Rule.Error()
14:57:44.112  TestStep         at OpenTap.Python.VirtualValidationRule.<.ctor>b__4_0()
14:57:44.112  TestStep         at Keysight.OpenTap.Gui.TestStepRowItem.b()
14:57:44.158  TestStep     Exception caught at:
14:57:44.163  TestStep         at System.String get_Error()
14:57:44.163  TestStep         at Void a()
14:57:44.163  TestStep         at Void a(System.Object, Keysight.OpenTap.Wpf.UpdateEventArgs)
14:57:44.163  TestStep         at Void Invoke(System.Object, TEventArgs)
14:57:44.163  TestStep         ...
```