### PR TITLE
116 Error when a library used in a Test Step logs warning: fix

### DIFF
--- a/OpenTap.Python/opentap.py
+++ b/OpenTap.Python/opentap.py
@@ -135,7 +135,8 @@ class Logger:
 
     def flush(self):
         self.log.Flush()
-        self.terminal.flush()
+        if self.terminal is not None:
+            self.terminal.flush()
 
 sys.stdout = Logger()
 sys.stderr = Logger(level = OpenTap.LogEventType.Error)


### PR DESCRIPTION
Fixed error when logger is flushed, but no terminal exists

Fixes https://github.com/opentap/OpenTap.Python/issues/116