### PR TITLE
Added code to detect which python version is loaded

### DIFF
--- a/OpenTap.Python/PythonInstallationDiscoverer.cs
+++ b/OpenTap.Python/PythonInstallationDiscoverer.cs
@@ -32,7 +32,7 @@ class PythonDiscoverer
             .Where(x => x.lib != null && File.Exists(x.lib))
             .OrderByDescending(x => x.weight)
             .ToArray()
-            .Where(x => GetVersion(x.lib, out int major, out int minor) && minor <= maxSupportedMinorVersion && minor >= minSupportedMinorVersion && major == supportedMajorVersion)
+            .Where(x => SharedLib.IsMacOs || GetVersion(x.lib, out int major, out int minor) && minor <= maxSupportedMinorVersion && minor >= minSupportedMinorVersion && major == supportedMajorVersion)
             .Select(x => (x.lib, x.pyPath));
     }
 

--- a/OpenTap.Python/PythonInstallationDiscoverer.cs
+++ b/OpenTap.Python/PythonInstallationDiscoverer.cs
@@ -32,14 +32,18 @@ class PythonDiscoverer
             .Where(x => x.lib != null && File.Exists(x.lib))
             .OrderByDescending(x => x.weight)
             .ToArray()
+            // only specific python version are supported. This is detected by trying to load the dll and get the python version from it.
+            // this does not work on MacOS, so there we just assume that its ok.
             .Where(x => SharedLib.IsMacOs || GetVersion(x.lib, out int major, out int minor) && minor <= maxSupportedMinorVersion && minor >= minSupportedMinorVersion && major == supportedMajorVersion)
             .Select(x => (x.lib, x.pyPath));
     }
 
     delegate IntPtr IntPtrF();
 
+    
     static bool GetVersion(string libPath, out int major, out int minor)
     {
+        // try parsing the version from the python function stymbols.
         major = 0;
         minor = 0;
         

--- a/OpenTap.Python/PythonInstallationDiscoverer.cs
+++ b/OpenTap.Python/PythonInstallationDiscoverer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 namespace OpenTap.Python;
@@ -20,14 +21,44 @@ class PythonDiscoverer
                 yield return $"3.{pythonVersionParser.Match(ins.library).Groups["v"].Value}";
         }
     }
+
+    const int minSupportedMinorVersion = 7;
+    const int maxSupportedMinorVersion = 12;
+    const int supportedMajorVersion = 3;
     
     public IEnumerable<(string library, string pyPath)> GetAvailablePythonInstallations()
     {
         return GetAvailablePythonInstallationCandidates()
             .Where(x => x.lib != null && File.Exists(x.lib))
             .OrderByDescending(x => x.weight)
+            .ToArray()
+            .Where(x => GetVersion(x.lib, out int major, out int minor) && minor <= maxSupportedMinorVersion && minor >= minSupportedMinorVersion && major == supportedMajorVersion)
             .Select(x => (x.lib, x.pyPath));
     }
+
+    delegate IntPtr IntPtrF();
+
+    static bool GetVersion(string libPath, out int major, out int minor)
+    {
+        major = 0;
+        minor = 0;
+        
+        var sh = SharedLib.Load(libPath);
+
+        var versionSymbol = sh.GetSymbol("Py_GetVersion");
+        if (versionSymbol == IntPtr.Zero) 
+            return false;
+        
+        var versionFunc = Marshal.GetDelegateForFunctionPointer<IntPtrF>(versionSymbol);
+        var versionStringPtr = versionFunc();
+        if (versionStringPtr == IntPtr.Zero)
+            return false;
+        
+        var versionString = Marshal.PtrToStringAnsi(versionStringPtr);
+        
+        return int.TryParse(versionString.Split('.').ElementAtOrDefault(0) ?? "", out major) && int.TryParse(versionString.Split('.').ElementAtOrDefault(1) ?? "", out minor);
+    }
+    
     static IEnumerable<string> GetPythonsInFolder(string folderPath)
     {
         try

--- a/OpenTap.Python/SharedLib.cs
+++ b/OpenTap.Python/SharedLib.cs
@@ -131,7 +131,22 @@ class SharedLib
     public SharedLib(IntPtr ptr)
     {
         lib = ptr;
+    }
+    
+    [DllImport("kernel32", CharSet = CharSet.Ansi, SetLastError = true)]
+    static extern IntPtr GetProcAddress(IntPtr hModule, string procName);
+    [DllImport("libdl.so", CharSet = CharSet.Ansi)]
+    static extern IntPtr dlsym(IntPtr handle, string symbol);
+    
+    public IntPtr GetSymbol(string symbolName)
+    {
+        if (lib == IntPtr.Zero)
+            throw new InvalidOperationException("Library handle is null.");
         
+        if (IsWin32)
+            return GetProcAddress(lib, symbolName);
+        
+        return dlsym(lib, symbolName);
     }
 
     public static SharedLib Load(string name)


### PR DESCRIPTION
we now no longer try to load a python version greater than 9.12. 

This can be changed in the future.