### PR TITLE
This fixes an issue causing Python to load plugins from the wrong dir…

### DIFF
--- a/OpenTap.Python/PythonInstallAction.cs
+++ b/OpenTap.Python/PythonInstallAction.cs
@@ -12,7 +12,10 @@ public class PythonInstallAction : ICustomPackageAction
     public bool Execute(PackageDef package, CustomPackageActionArgs customActionArgs)
     {
         if (PythonInitializer.LoadPython() == false)
+        {
+            log.Debug("Unable to load python. Skipping python install actions.");
             return true;
+        }
         using (Py.GIL())
         {
             var opentap = Py.Import("opentap");

--- a/OpenTap.Python/PythonSettings.cs
+++ b/OpenTap.Python/PythonSettings.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using OpenTap.Package;
 
 namespace OpenTap.Python
 {
@@ -43,7 +44,7 @@ namespace OpenTap.Python
         public string[] GetSearchList()
         {
             var lst = new List<string>();
-            var dir = Path.GetDirectoryName(typeof(TestPlan).Assembly.Location);
+            var dir = Installation.Current.Directory;
             lst.Add(dir);
             var dir2 = Path.Combine(dir, "Packages", "Python");
             if (Directory.Exists(dir2))


### PR DESCRIPTION
…ectory when running isolated

This is required as part of the solution to https://github.com/opentap/OpenTap.Python/issues/149

This is needed in cases where Python is not installed at the start of an installation, (and thus is not copied into the isolated directory)